### PR TITLE
V2: Limit Performer Naming Tokens To 4 Names

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -474,9 +474,25 @@ namespace NzbDrone.Core.Organizer
                 tokenHandlers["{Release Date}"] = m => "Unknown";
             }
 
-            tokenHandlers["{Episode Performers}"] = m => episodes.SelectMany(e => e.Actors.Select(a => a.Name)).Join(" ");
-            tokenHandlers["{Episode PerformersFemale}"] = m => episodes.SelectMany(e => e.Actors.Where(a => a.Gender == Gender.Female).Select(a => a.Name)).Join(" ");
-            tokenHandlers["{Episode PerformersMale}"] = m => episodes.SelectMany(e => e.Actors.Where(a => a.Gender == Gender.Male).Select(a => a.Name)).Join(" ");
+            tokenHandlers["{Episode Performers}"] = m =>
+            {
+                var allPerformers = episodes.SelectMany(e => e.Actors.Select(a => a.Name)).Distinct().Take(4).ToList();
+                return string.Join(", ", allPerformers);
+            };
+            tokenHandlers["{Episode PerformersFemale}"] = m =>
+            {
+                var femalePerformers = episodes
+                    .SelectMany(e => e.Actors.Where(a => a.Gender == Gender.Female).Select(a => a.Name)).Distinct()
+                    .Take(4).ToList();
+                return string.Join(", ", femalePerformers);
+            };
+            tokenHandlers["{Episode PerformersMale}"] = m =>
+            {
+                var malePerformers = episodes
+                    .SelectMany(e => e.Actors.Where(a => a.Gender == Gender.Male).Select(a => a.Name)).Distinct()
+                    .Take(4).ToList();
+                return string.Join(", ", malePerformers);
+            };
         }
 
         private void AddEpisodeTitlePlaceholderTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers)

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -477,21 +477,21 @@ namespace NzbDrone.Core.Organizer
             tokenHandlers["{Episode Performers}"] = m =>
             {
                 var allPerformers = episodes.SelectMany(e => e.Actors.Select(a => a.Name)).Distinct().Take(4).ToList();
-                return string.Join(", ", allPerformers);
+                return string.Join(" ", allPerformers);
             };
             tokenHandlers["{Episode PerformersFemale}"] = m =>
             {
                 var femalePerformers = episodes
                     .SelectMany(e => e.Actors.Where(a => a.Gender == Gender.Female).Select(a => a.Name)).Distinct()
                     .Take(4).ToList();
-                return string.Join(", ", femalePerformers);
+                return string.Join(" ", femalePerformers);
             };
             tokenHandlers["{Episode PerformersMale}"] = m =>
             {
                 var malePerformers = episodes
                     .SelectMany(e => e.Actors.Where(a => a.Gender == Gender.Male).Select(a => a.Name)).Distinct()
                     .Take(4).ToList();
-                return string.Join(", ", malePerformers);
+                return string.Join(" ", malePerformers);
             };
         }
 


### PR DESCRIPTION

#### Description
Updates the performerTokes so that they are limited to 4 performers each. Users are having issue with lots of names causing renaming errors. 


* Fixes #433